### PR TITLE
Add support for XCode 14

### DIFF
--- a/Charts.podspec
+++ b/Charts.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "Charts"
-  s.version = "3.7.0"
+  s.version = "3.7.1"
   s.summary = "Charts is a powerful & easy to use chart library for iOS, tvOS and OSX (and Android)"
   s.homepage = "https://github.com/danielgindi/Charts"
   s.license = { :type => "Apache License, Version 2.0", :file => "LICENSE" }

--- a/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
+++ b/Source/Charts/Data/Implementations/Standard/ChartDataSet.swift
@@ -571,4 +571,9 @@ extension ChartDataSet: RangeReplaceableCollection {
         entries.removeAll(keepingCapacity: keepCapacity)
         notifyDataSetChanged()
     }
+    
+    public func replaceSubrange<C>(_ subrange: Swift.Range<Int>, with newElements: C) where C : Collection, ChartDataEntry == C.Element {
+        entries.replaceSubrange(subrange, with: newElements)
+        notifyDataSetChanged()
+    }
 }


### PR DESCRIPTION
Missing method.

Xcode 14  issues.
Unavailable instance method 'replaceSubrange(_:with:)' was used to satisfy a requirement of protocol 'RangeReplaceableCollection'

Issue

Xcode 14 issues.
Unavailable instance method 'replaceSubrange(_:with:)' was used to satisfy a requirement of protocol 'RangeReplaceableCollection'

Goals ⚽

Instance method 'replaceSubrange(_:with:)' need to adding.

Implementation Details 🚧

Added unavailable instance method 'replaceSubrange(_:with:)'.